### PR TITLE
Display contribution types descriptions on form

### DIFF
--- a/templates/default/paypal_form.html.twig
+++ b/templates/default/paypal_form.html.twig
@@ -48,6 +48,9 @@
                                                     {% endif %}
                                                 </label>
                                             </div>
+                                            {% if amount['description'] is defined and amount['description'] is not empty %}
+                                                <div class="ui visible info message amount-description">{{ amount['description']|raw }}</div>
+                                            {% endif %}
                                         </div>
                                     {% endfor %}
                                 </div>

--- a/webroot/galette_paypal.css
+++ b/webroot/galette_paypal.css
@@ -2,3 +2,7 @@ em[data-emoji=":paypal:"]::before,
 em[data-emoji="paypal"]::before {
     background-image: url(./images/paypal.svg);
 }
+
+.ui.message.amount-description {
+  margin-left:1.85714em;
+}


### PR DESCRIPTION
Depends on galette/galette#793
<img width="1004" height="457" alt="paypal" src="https://github.com/user-attachments/assets/3b97b750-ac44-4528-9d91-6ae707a43108" />
